### PR TITLE
Remove UNION from sessions and users views

### DIFF
--- a/sessions.view.lkml
+++ b/sessions.view.lkml
@@ -179,12 +179,6 @@ view: sessions {
         ON a.session_id = b.session_id
 
       WHERE a.page_view_in_session_index = 1
-
-      UNION
-
-      SELECT
-        *
-      FROM derived.sessions_webtrends
        ;;
     sql_trigger_value: SELECT COUNT(*) FROM ${page_views.SQL_TABLE_NAME} ;;
     distribution: "user_snowplow_domain_id"

--- a/users.view.lkml
+++ b/users.view.lkml
@@ -121,12 +121,6 @@ view: users {
         ON a.user_snowplow_domain_id = b.user_snowplow_domain_id
 
       WHERE a.session_index = 1
-
-      UNION
-
-      SELECT
-        *
-      FROM derived.users_webtrends
        ;;
     sql_trigger_value: SELECT COUNT(*) FROM ${sessions.SQL_TABLE_NAME} ;;
     distribution: "user_snowplow_domain_id"


### PR DESCRIPTION
@danpollock as the sessions and users tables are built from the page views tables, the WebTrends data will already be included! Apologies for the confusion. 