### PR TITLE
GDXDSD-417 updating the ip address filter to remove the first percent

### DIFF
--- a/page_views.view.lkml
+++ b/page_views.view.lkml
@@ -644,7 +644,7 @@ view: page_views {
 
   dimension: is_government {
     type: yesno
-    sql: ${ip_address} LIKE '%142%' ;;
+    sql: ${ip_address} LIKE '142%' ;;
   }
 
   dimension: ip_address {

--- a/page_views.view.lkml
+++ b/page_views.view.lkml
@@ -643,7 +643,9 @@ view: page_views {
   # IP
 
   dimension: is_government {
+    # the filter is put in this view because the IP is defined here in this view
     type: yesno
+    # the filter is using the frist part of the gov ip - 142.xxx.xxx.xxx to see if the IP is in the gov network
     sql: ${ip_address} LIKE '142%' ;;
   }
 


### PR DESCRIPTION
to explain the %, the gov ip is 142.xxx.xxx.xxx and to have a wild card in front of the 142 could cause an issue because it is looking for that pattern in any location in the IP. To be clear the filter should only see if the ip starts with 142.